### PR TITLE
mosquitto_tls_insecure_set() requires libmosq>=1.2

### DIFF
--- a/mqtt-chronos.c
+++ b/mqtt-chronos.c
@@ -261,10 +261,12 @@ int main(int argc, char **argv)
 		/* FIXME */
 		// mosquitto_tls_opts_set(m, SSL_VERIFY_PEER, "tlsv1", NULL);
 		
-		/* FIXME detect 1.2 */
+#if LIBMOSQUITTO_VERSION_NUMBER >= 1002000
+		/* mosquitto_tls_insecure_set() requires libmosquitto 1.2. */
 		if (tls_insecure) {
-			// mosquitto_tls_insecure_set(m, TRUE);
+			mosquitto_tls_insecure_set(m, TRUE);
 		}
+#endif
 	}
 
 	if ((rc = mosquitto_connect(m, host, port, keepalive)) != MOSQ_ERR_SUCCESS) {


### PR DESCRIPTION
This commit detects libmosq>=1.2 at compile time to allow mosquitto_tls_insecure_set() to be used when present.
